### PR TITLE
fix: layout shifts 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[[headers]]
+  for = "/static/*.woff2"
+  [headers.values]
+    # in seconds: cache for 6 months
+    cache-control = '''
+    max-age=15768000,
+    public
+    immutable'''

--- a/src/components/Bio.js
+++ b/src/components/Bio.js
@@ -20,6 +20,8 @@ function Bio() {
             <img
               src={profilePic}
               alt={author}
+              width="50"
+              height="50"
               style={{
                 margin: rhythm(1 / 2),
                 width: 50,

--- a/src/components/Bio.js
+++ b/src/components/Bio.js
@@ -29,7 +29,7 @@ function Bio() {
                 borderRadius: `100%`,
               }}
             />
-            <p>
+            <p className='intro-text'>
               Written by <strong>{author}</strong>, author of{' '}
               <a href="https://package.elm-lang.org/packages/jfmengels/elm-review/latest/">
                 elm-review

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -16,7 +16,6 @@ class Layout extends React.Component {
             ...scale(1.5),
             marginBottom: rhythm(1.5),
             marginTop: 0,
-            fontFamily: "Merriweather, Georgia, sans-serif"
           }}
         >
           <Link

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -16,6 +16,7 @@ class Layout extends React.Component {
             ...scale(1.5),
             marginBottom: rhythm(1.5),
             marginTop: 0,
+            fontFamily: "Merriweather, Georgia, sans-serif"
           }}
         >
           <Link

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -3,6 +3,12 @@ import Wordpress2016 from 'typography-theme-wordpress-2016'
 
 Wordpress2016.overrideThemeStyles = () => {
   return {
+    'h1': {
+      fontFamily: "Montserrat, Georgia, sans-serif",
+    },
+    ".intro-text": {
+      fontSize: "104%",
+    },
     'a.gatsby-resp-image-link': {
       boxShadow: `none`,
     },


### PR DESCRIPTION
# Summary


## Motivation
Fixing layout shift on first visit and hard reload. You won't notice it probably but if you scrub video on exactly right moment it's quite noticeable.

### Typography
* Fonts where not caching so I added netlify config to make it catch for 6months.
* I added `.intro-text` increased it's size because that size matches better with length of line generated by Merriweather.


### Image
I wasn't able to figure out why those inline styles where not applied in this specific case, so but adding inline attribute without units will reserve place for image that will load later.


preview: https://deploy-preview-1--jurun.netlify.app/

### Before: Hard Reload slow 3g
https://github.com/ultrox/blog-2/assets/3077558/bcf3ca8d-76e8-4bbe-9f17-a45a97b644a4

### After: Hard Reload slow 3g
https://github.com/ultrox/blog-2/assets/3077558/847016d4-f746-41ef-affe-57cd878583d0



